### PR TITLE
Use the AsyncPackage.JoinableTaskFactory instead of ThreadHelper. Fixes #7

### DIFF
--- a/src/VSSDK.Helpers.Shared/Wrappers/CommandBase.cs
+++ b/src/VSSDK.Helpers.Shared/Wrappers/CommandBase.cs
@@ -54,7 +54,8 @@ namespace Microsoft.VisualStudio.Helpers
 
         private void ExecuteInternal(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+            Assumes.Present(Package);
+            Package?.JoinableTaskFactory.RunAsync(async delegate
             {
                 try
                 {


### PR DESCRIPTION
Replace ThreadHelper.JTF with the package JTF when running async tasks.