### PR TITLE
Moved common project properties to a shared props file.

### DIFF
--- a/Community.VisualStudio.Toolkit.sln
+++ b/Community.VisualStudio.Toolkit.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31101.43
@@ -13,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
+		src\Community.VisualStudio.Toolkit.props = src\Community.VisualStudio.Toolkit.props
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -20,9 +20,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSSDK.TestExtension", "test
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{38dc82ea-91d6-4360-b76c-995708ee43a3}*SharedItemsImports = 5
 		src\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{5ec463ac-24cb-443e-9ff9-91b7ecb1f822}*SharedItemsImports = 13
-		src\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{a9e80c7b-8ed1-4d7b-b1f3-575fd70001ba}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Community.VisualStudio.Toolkit.15.0/Community.VisualStudio.Toolkit.15.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.15.0/Community.VisualStudio.Toolkit.15.0.csproj
@@ -1,32 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Community.VisualStudio.Toolkit.props"/>
+  
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
     <Version>15.0</Version>
-    <Authors>Mads Kristensen</Authors>
-    <Owners>Mads Kristensen</Owners>
-    <Copyright>© Mads Kristensen. All rights reserved.</Copyright>
-    <RepositoryUrl>https://github.com/madskristensen/VSSDK.Helpers</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>portable</DebugType>
-
-    <PackageId>Community.VisualStudio.Toolkit</PackageId>
-    <PackageDescription>A community driven effort for a better Visual Studio experience developing extensions.</PackageDescription>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageIcon>Icon.png</PackageIcon>
-    <PackageTags>VisualStudio, VSSDK, SDK</PackageTags>
-    <RootNamespace>Community.VisualStudio.Toolkit</RootNamespace>
-
-    <LangVersion>9</LangVersion>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,22 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\Icon.png" Link="Icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Windows" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <Import Project="..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
@@ -1,32 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Community.VisualStudio.Toolkit.props"/>
+
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <Version>16.0</Version>
-    <Authors>Mads Kristensen</Authors>
-    <Owners>Mads Kristensen</Owners>
-    <Copyright>© Mads Kristensen. All rights reserved.</Copyright>
-    <RepositoryUrl>https://github.com/madskristensen/VSSDK.Helpers</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>portable</DebugType>
-    
-    <PackageId>Community.VisualStudio.Toolkit</PackageId>
-    <PackageDescription>A community driven effort for a better Visual Studio experience developing extensions.</PackageDescription>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageIcon>Icon.png</PackageIcon>
-    <PackageTags>VisualStudio, VSSDK, SDK</PackageTags>
-    <RootNamespace>Community.VisualStudio.Toolkit</RootNamespace>
-
-    <LangVersion>9</LangVersion>
-    <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,22 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\Icon.png" Link="Icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Windows" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
-  <Import Project="..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/Community.VisualStudio.Toolkit.props
+++ b/src/Community.VisualStudio.Toolkit.props
@@ -1,0 +1,44 @@
+<Project>
+
+  <PropertyGroup>
+    <Authors>Mads Kristensen</Authors>
+    <Owners>Mads Kristensen</Owners>
+    <Copyright>© Mads Kristensen. All rights reserved.</Copyright>
+    <RepositoryUrl>https://github.com/madskristensen/VSSDK.Helpers</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    
+    <PackageId>Community.VisualStudio.Toolkit</PackageId>
+    <PackageDescription>A community driven effort for a better Visual Studio experience developing extensions.</PackageDescription>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageIcon>Icon.png</PackageIcon>
+    <PackageTags>VisualStudio, VSSDK, SDK</PackageTags>
+    <RootNamespace>Community.VisualStudio.Toolkit</RootNamespace>
+
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Link="Icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Windows" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
+
+</Project>


### PR DESCRIPTION
There were a lot of common properties in the project files for v15 and v16. I've moved them to a `.props` file, which should make it easier to keep the two properties in sync.