### PR TITLE
Changed the namespace for TextBufferExtensions to match the namespace of ITextBuffer

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/TextBufferExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/TextBufferExtensions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 
-namespace VSSDK.Helpers.Shared.Extensions
+namespace Microsoft.VisualStudio.Text
 {
     /// <summary>Extension methods for the ITextBuffer interface.</summary>
     public static class TextBufferExtensions


### PR DESCRIPTION
I noticed the namespace of `TextBufferExtensions` was using the old project's namespace. I've changed it to be the same namespace as `ITextBuffer`, which is the same pattern that the other extension methods use.