### PR TITLE
TestExtension should reference the Toolkit project in the solution, not the nuget package (fixes #16)

### DIFF
--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -74,9 +74,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Community.VisualStudio.Toolkit" ExcludeAssets="Runtime">
-      <Version>16.0.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.10.23">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -94,6 +91,12 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <LastGenOutput>VSCommandTable.cs</LastGenOutput>
     </VSCTCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Community.VisualStudio.Toolkit.16.0\Community.VisualStudio.Toolkit.16.0.csproj">
+      <Project>{38dc82ea-91d6-4360-b76c-995708ee43a3}</Project>
+      <Name>Community.VisualStudio.Toolkit.16.0</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />


### PR DESCRIPTION
Now references the Toolkit.16.0 project in the solution instead of the nuget package. Fixes #16