### PR TITLE
Added VS.Initialize and VS.JoinableTaskFactory

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/TaskExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/TaskExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Community.VisualStudio.Toolkit;
 
 namespace Microsoft.VisualStudio.Shell
 {
@@ -14,7 +15,7 @@ namespace Microsoft.VisualStudio.Shell
         /// </remarks>
         public static void FireAndForget(this System.Threading.Tasks.Task task)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            VS.JoinableTaskFactory.RunAsync(async () =>
             {
                 try
                 {

--- a/src/Community.VisualStudio.Toolkit.Shared/VS.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/VS.cs
@@ -3,6 +3,7 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 
 namespace Community.VisualStudio.Toolkit
 {
@@ -11,6 +12,23 @@ namespace Community.VisualStudio.Toolkit
     /// </summary>
     public static class VS
     {
+        private static JoinableTaskFactory _jtf = ThreadHelper.JoinableTaskFactory;
+
+        /// <summary>
+        /// Initializes the entry point.
+        /// This is an optional but recommended step in order to optimize use of the JoinableTaskFactory.
+        /// Call this method at the start of the extension's AsyncPackage's InitializeAsync method and pass
+        /// the AsyncPackage.JoinableTaskFactory as the argument.
+        /// </summary>
+        /// <param name="jtf">The JoinableTaskFactory instance from the extension's AsyncPackage.</param>
+        public static void Initialize(JoinableTaskFactory jtf)
+        {
+            _jtf = jtf;
+        }
+
+        /// <summary>The JoinableTaskFactory either from the extension's package or from ThreadHelper. See <see cref="Initialize(JoinableTaskFactory)"/>.</summary>
+        public static JoinableTaskFactory JoinableTaskFactory => _jtf;
+
         /// <summary>A collection of services related to the command system.</summary>
         public static Commanding Commanding => new();
 

--- a/test/VSSDK.TestExtension/VSSDK.TestExtensionPackage.cs
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtensionPackage.cs
@@ -27,6 +27,8 @@ namespace VSSDK.TestExtension
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            VS.Initialize(JoinableTaskFactory);
+
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             await TestCommand.InitializeAsync(this);
             await RunnerWindowCommand.InitializeAsync(this);


### PR DESCRIPTION
`VS.Initialize` is a new, optional method that extension authors can (preferably should) call during their AsyncPackage's InitializeAsync, and pass in their AsyncPackage's JoinableTaskFactory instance.

By default, the `VS.JoinableTaskFactory` property returns the `ThreadHelper.JoinableTaskFactory` instance.

But if the extension calls VS.Initialize then `VS.JoinableTaskFactory` will subsequently return the extension AsyncPackage's JTF instance.

Classes in the Community.VisualStudio.Toolkit should use `VS.JoinableTaskFactory.RunAsync` instead of `ThreadHelper.JoinableTaskFactory.RunAsync` for the reasons outlined in https://github.com/madskristensen/Community.VisualStudio.Toolkit/issues/7

As a result, if an extension uses the Community.VisualStudio.Toolkit and chooses to call VS.Initialize then it will benefit from the task tracking that occurs with their extension package's JTF instance, because all async work started by the Toolkit will use their extension's JTF instance.